### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/pagination.py
+++ b/examples/pagination.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    print('Client version: %s' % client_version)
+    print('Client version: {0!s}'.format(client_version))
     api = Client(args.username, args.password)
 
     user_id = '2958144170'

--- a/examples/savesettings_logincallback.py
+++ b/examples/savesettings_logincallback.py
@@ -35,7 +35,7 @@ def onlogin_callback(api, new_settings_file):
     cache_settings = api.settings
     with open(new_settings_file, 'w') as outfile:
         json.dump(cache_settings, outfile, default=to_json)
-        print('SAVED: %s' % new_settings_file)
+        print('SAVED: {0!s}'.format(new_settings_file))
 
 
 if __name__ == '__main__':
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    print('Client version: %s' % client_version)
+    print('Client version: {0!s}'.format(client_version))
 
     device_id = None
     try:
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         settings_file = args.settings_file_path
         if not os.path.isfile(settings_file):
             # settings file does not exist
-            print('Unable to find file: %s' % settings_file)
+            print('Unable to find file: {0!s}'.format(settings_file))
 
             # login new
             api = Client(
@@ -73,7 +73,7 @@ if __name__ == '__main__':
         else:
             with open(settings_file) as file_data:
                 cached_settings = json.load(file_data, object_hook=from_json)
-            print('Reusing settings: %s' % settings_file)
+            print('Reusing settings: {0!s}'.format(settings_file))
 
             device_id = cached_settings.get('device_id')
             # reuse auth settings
@@ -82,7 +82,7 @@ if __name__ == '__main__':
                 settings=cached_settings)
 
     except (ClientCookieExpiredError, ClientLoginRequiredError) as e:
-        print('ClientCookieExpiredError/ClientLoginRequiredError: %s' % e)
+        print('ClientCookieExpiredError/ClientLoginRequiredError: {0!s}'.format(e))
 
         # Login expired
         # Do relogin but use default ua, keys and such
@@ -92,18 +92,18 @@ if __name__ == '__main__':
             on_login=lambda x: onlogin_callback(x, args.settings_file_path))
 
     except ClientLoginError as e:
-        print('ClientLoginError %s' % e)
+        print('ClientLoginError {0!s}'.format(e))
         exit(9)
     except ClientError as e:
-        print('ClientError %s (Code: %d, Response: %s)' % (e.msg, e.code, e.error_response))
+        print('ClientError {0!s} (Code: {1:d}, Response: {2!s})'.format(e.msg, e.code, e.error_response))
         exit(9)
     except Exception as e:
-        print('Unexpected Exception: %s' % e)
+        print('Unexpected Exception: {0!s}'.format(e))
         exit(99)
 
     # Show when login expires
     cookie_expiry = api.cookie_jar.expires_earliest
-    print('Cookie Expiry: %s' % datetime.datetime.fromtimestamp(cookie_expiry).strftime('%Y-%m-%dT%H:%M:%SZ'))
+    print('Cookie Expiry: {0!s}'.format(datetime.datetime.fromtimestamp(cookie_expiry).strftime('%Y-%m-%dT%H:%M:%SZ')))
 
     # Call the api
     results = api.tag_search('cats')

--- a/instagram_private_api/client.py
+++ b/instagram_private_api/client.py
@@ -124,7 +124,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
         cookie_string = kwargs.pop('cookie', None) or user_settings.get('cookie')
         cookie_jar = ClientCookieJar(cookie_string=cookie_string)
         if cookie_string and cookie_jar.expires_earliest and int(time.time()) >= cookie_jar.expires_earliest:
-            raise ClientCookieExpiredError('Oldest cookie expired at %s' % cookie_jar.expires_earliest)
+            raise ClientCookieExpiredError('Oldest cookie expired at {0!s}'.format(cookie_jar.expires_earliest))
         cookie_handler = compat_urllib_request.HTTPCookieProcessor(cookie_jar)
 
         proxy_handler = None
@@ -133,10 +133,10 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
             warnings.warn('Proxy support is alpha.', UserWarning)
             parsed_url = compat_urllib_parse_urlparse(proxy)
             if parsed_url.netloc and parsed_url.scheme:
-                proxy_address = '%s://%s' % (parsed_url.scheme, parsed_url.netloc)
+                proxy_address = '{0!s}://{1!s}'.format(parsed_url.scheme, parsed_url.netloc)
                 proxy_handler = compat_urllib_request.ProxyHandler({'https': proxy_address})
             else:
-                raise ValueError('Invalid proxy argument: %s' % proxy)
+                raise ValueError('Invalid proxy argument: {0!s}'.format(proxy))
         handlers = []
         if proxy_handler:
             handlers.append(proxy_handler)
@@ -211,8 +211,8 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
         """Override the useragent string with your own"""
         mobj = re.search(Constants.USER_AGENT_EXPRESSION, value)
         if not mobj:
-            raise ValueError('User-agent specified does not fit format required: %s' %
-                             Constants.USER_AGENT_EXPRESSION)
+            raise ValueError('User-agent specified does not fit format required: {0!s}'.format(
+                             Constants.USER_AGENT_EXPRESSION))
         self.app_version = mobj.group('app_version')
         self.android_release = mobj.group('android_release')
         self.android_version = int(mobj.group('android_version'))
@@ -261,8 +261,8 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
         """
         mobj = re.search(Constants.USER_AGENT_EXPRESSION, value)
         if not mobj:
-            raise ValueError('User-agent specified does not fit format required: %s' %
-                             Constants.USER_AGENT_EXPRESSION)
+            raise ValueError('User-agent specified does not fit format required: {0!s}'.format(
+                             Constants.USER_AGENT_EXPRESSION))
         parse_params = {
             'app_version': mobj.group('app_version'),
             'android_version': int(mobj.group('android_version')),
@@ -319,7 +319,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
     def rank_token(self):
         if not self.authenticated_user_id:
             return None
-        return '%s_%s' % (self.authenticated_user_id, self.uuid)
+        return '{0!s}_{1!s}'.format(self.authenticated_user_id, self.uuid)
 
     @property
     def authenticated_params(self):
@@ -344,7 +344,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
             'Accept-Encoding': 'gzip, deflate',
             'X-IG-Capabilities': self.ig_capabilities,
             'X-IG-Connection-Type': 'WIFI',
-            'X-IG-Connection-Speed': '%dkbps' % random.randint(1000, 5000),
+            'X-IG-Connection-Speed': '{0:d}kbps'.format(random.randint(1000, 5000)),
         }
 
     @property
@@ -384,7 +384,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
         :param seed: Seed value to generate a consistent device ID
         :return:
         """
-        return 'android-%s' % cls.generate_uuid(True, seed)[:16]
+        return 'android-{0!s}'.format(cls.generate_uuid(True, seed)[:16])
 
     def generate_adid(self, seed=None):
         """
@@ -446,13 +446,13 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
 
         req = compat_urllib_request.Request(url, data, headers=headers)
         try:
-            self.logger.debug('REQUEST: %s %s' % (url, req.get_method()))
-            self.logger.debug('DATA: %s' % data)
+            self.logger.debug('REQUEST: {0!s} {1!s}'.format(url, req.get_method()))
+            self.logger.debug('DATA: {0!s}'.format(data))
             response = self.opener.open(req, timeout=self.timeout)
         except compat_urllib_error.HTTPError as e:
             error_msg = e.reason
             error_response = self._read_response(e)
-            self.logger.debug('RESPONSE: %d %s' % (e.code, error_response))
+            self.logger.debug('RESPONSE: {0:d} {1!s}'.format(e.code, error_response))
             try:
                 error_obj = json.loads(error_response)
                 if error_obj.get('message') == 'login_required':
@@ -464,7 +464,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
                         error_obj.get('message'), code=e.code,
                         error_response=json.dumps(error_obj))
                 elif error_obj.get('message'):
-                    error_msg = '%s: %s' % (e.reason, error_obj['message'])
+                    error_msg = '{0!s}: {1!s}'.format(e.reason, error_obj['message'])
             except (ClientLoginError, ClientLoginRequiredError, ClientThrottledError):
                 raise
             except:
@@ -476,7 +476,7 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
             return response
 
         response_content = self._read_response(response)
-        self.logger.debug('RESPONSE: %d %s' % (response.code, response_content))
+        self.logger.debug('RESPONSE: {0:d} {1!s}'.format(response.code, response_content))
         json_response = json.loads(response_content)
 
         if json_response.get('message', '') == 'login_required':

--- a/instagram_private_api/compatpatch.py
+++ b/instagram_private_api/compatpatch.py
@@ -123,7 +123,7 @@ class ClientCompatPatch():
     @classmethod
     def media(cls, media, drop_incompat_keys=False):
         """Patch a media object"""
-        media['link'] = 'https://www.instagram.com/p/%s/' % media['code']
+        media['link'] = 'https://www.instagram.com/p/{0!s}/'.format(media['code'])
         media['created_time'] = str(int(media.get('taken_at') or media.get('device_timestamp')))
 
         if media['media_type'] == 1:

--- a/instagram_private_api/endpoints/accounts.py
+++ b/instagram_private_api/endpoints/accounts.py
@@ -38,7 +38,7 @@ class AccountsEndpointsMixin(object):
         except compat_urllib_error.HTTPError as e:
             error_response = self._read_response(e)
             if e.code == 400:
-                raise ClientLoginError('Unable to login: %s' % e)
+                raise ClientLoginError('Unable to login: {0!s}'.format(e))
             raise ClientError(e.reason, e.code, error_response)
 
         if not self.csrftoken:
@@ -86,7 +86,7 @@ class AccountsEndpointsMixin(object):
         :return:
         """
         if int(gender) not in [1, 2, 3]:
-            raise ValueError('Invalid gender: %d' % int(gender))
+            raise ValueError('Invalid gender: {0:d}'.format(int(gender)))
         if not email:
             raise ValueError('Email is required.')
 
@@ -146,7 +146,7 @@ class AccountsEndpointsMixin(object):
             try:
                 error_obj = json.loads(error_response)
                 if error_obj.get('message'):
-                    error_msg = '%s: %s' % (e.reason, error_obj['message'])
+                    error_msg = '{0!s}: {1!s}'.format(e.reason, error_obj['message'])
             except:
                 # do nothing, prob can't parse json
                 pass

--- a/instagram_private_api/endpoints/collections.py
+++ b/instagram_private_api/endpoints/collections.py
@@ -14,7 +14,7 @@ class CollectionsEndpointsMixin(object):
         :param collection_id: Collection ID
         :return:
         """
-        endpoint = 'feed/collection/%(collection_id)s/' % {'collection_id': collection_id}
+        endpoint = 'feed/collection/{collection_id!s}/'.format(**{'collection_id': collection_id})
         res = self._call_api(endpoint)
         if self.auto_patch and res.get('items'):
             [ClientCompatPatch.media(m['media'], drop_incompat_keys=self.drop_incompat_keys)
@@ -74,7 +74,7 @@ class CollectionsEndpointsMixin(object):
             'added_media_ids': json.dumps(added_media_ids, separators=(',', ':'))
         }
         params.update(self.authenticated_params)
-        endpoint = 'collections/%(collection_id)s/edit/' % {'collection_id': collection_id}
+        endpoint = 'collections/{collection_id!s}/edit/'.format(**{'collection_id': collection_id})
         return self._call_api(endpoint, params=params)
 
     def delete_collection(self, collection_id):
@@ -90,5 +90,5 @@ class CollectionsEndpointsMixin(object):
                 }
         """
         params = self.authenticated_params
-        endpoint = 'collections/%(collection_id)s/delete/' % {'collection_id': collection_id}
+        endpoint = 'collections/{collection_id!s}/delete/'.format(**{'collection_id': collection_id})
         return self._call_api(endpoint, params=params)

--- a/instagram_private_api/endpoints/feed.py
+++ b/instagram_private_api/endpoints/feed.py
@@ -62,7 +62,7 @@ class FeedEndpointsMixin(object):
             - **min_timestamp**: For pagination
         :return:
         """
-        endpoint = 'feed/user/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'feed/user/{user_id!s}/'.format(**{'user_id': user_id})
         query = {'rank_token': self.rank_token, 'ranked_content': 'true'}
         query.update(kwargs)
         res = self._call_api(endpoint, query=query)
@@ -86,7 +86,7 @@ class FeedEndpointsMixin(object):
             - **min_timestamp**: For pagination
         :return:
         """
-        endpoint = 'feed/user/%(user_name)s/username/' % {'user_name': user_name}
+        endpoint = 'feed/user/{user_name!s}/username/'.format(**{'user_name': user_name})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             [ClientCompatPatch.media(m, drop_incompat_keys=self.drop_incompat_keys)
@@ -112,7 +112,7 @@ class FeedEndpointsMixin(object):
         :param kwargs:
         :return:
         """
-        endpoint = 'feed/user/%(user_id)s/reel_media/' % {'user_id': user_id}
+        endpoint = 'feed/user/{user_id!s}/reel_media/'.format(**{'user_id': user_id})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             [ClientCompatPatch.media(m, drop_incompat_keys=self.drop_incompat_keys)
@@ -148,7 +148,7 @@ class FeedEndpointsMixin(object):
         :param tag:
         :return:
         """
-        endpoint = 'feed/tag/%(tag)s/' % {'tag': tag}
+        endpoint = 'feed/tag/{tag!s}/'.format(**{'tag': tag})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             if res.get('items'):
@@ -166,7 +166,7 @@ class FeedEndpointsMixin(object):
         :param user_id:
         :return:
         """
-        endpoint = 'feed/user/%(user_id)s/story/' % {'user_id': user_id}
+        endpoint = 'feed/user/{user_id!s}/story/'.format(**{'user_id': user_id})
         res = self._call_api(endpoint)
         if self.auto_patch and res.get('reel'):
             [ClientCompatPatch.media(m, drop_incompat_keys=self.drop_incompat_keys)
@@ -180,7 +180,7 @@ class FeedEndpointsMixin(object):
         :param location_id:
         :return:
         """
-        endpoint = 'feed/location/%(location_id)s/' % {'location_id': location_id}
+        endpoint = 'feed/location/{location_id!s}/'.format(**{'location_id': location_id})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             if res.get('items'):

--- a/instagram_private_api/endpoints/friendships.py
+++ b/instagram_private_api/endpoints/friendships.py
@@ -24,7 +24,7 @@ class FriendshipsEndpointsMixin(object):
             - **max_id**: For pagination
         :return:
         """
-        endpoint = 'friendships/%(user_id)s/following/' % {'user_id': user_id}
+        endpoint = 'friendships/{user_id!s}/following/'.format(**{'user_id': user_id})
         query = {
             'rank_token': self.rank_token,
         }
@@ -44,7 +44,7 @@ class FriendshipsEndpointsMixin(object):
             - **max_id**: For pagination
         :return:
         """
-        endpoint = 'friendships/%(user_id)s/followers/' % {'user_id': user_id}
+        endpoint = 'friendships/{user_id!s}/followers/'.format(**{'user_id': user_id})
         query = {
             'rank_token': self.rank_token,
         }
@@ -83,7 +83,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/show/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/show/{user_id!s}/'.format(**{'user_id': user_id})
         res = self._call_api(endpoint)
         return res
 
@@ -138,7 +138,7 @@ class FriendshipsEndpointsMixin(object):
                     }
                 }
         """
-        endpoint = 'friendships/create/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/create/{user_id!s}/'.format(**{'user_id': user_id})
         params = {'user_id': user_id, 'radio_type': self.radio_type}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -165,7 +165,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/destroy/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/destroy/{user_id!s}/'.format(**{'user_id': user_id})
         params = {'user_id': user_id, 'radio_type': self.radio_type}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -191,7 +191,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/block/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/block/{user_id!s}/'.format(**{'user_id': user_id})
         params = {'user_id': user_id}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -217,7 +217,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/unblock/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/unblock/{user_id!s}/'.format(**{'user_id': user_id})
         params = {'user_id': user_id}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -243,7 +243,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/block_friend_reel/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/block_friend_reel/{user_id!s}/'.format(**{'user_id': user_id})
         params = {'source': 'main_feed'}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -269,7 +269,7 @@ class FriendshipsEndpointsMixin(object):
                     "is_private": false
                 }
         """
-        endpoint = 'friendships/unblock_friend_reel/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'friendships/unblock_friend_reel/{user_id!s}/'.format(**{'user_id': user_id})
         res = self._call_api(endpoint, params=self.authenticated_params)
         return res
 
@@ -306,7 +306,7 @@ class FriendshipsEndpointsMixin(object):
         """
 
         if block_status not in ['block', 'unblock']:
-            raise ValueError('Invalid block_status: %s' % block_status)
+            raise ValueError('Invalid block_status: {0!s}'.format(block_status))
         if not isinstance(user_ids, list):
             user_ids = [user_ids]
         params = {'source': 'settings'}

--- a/instagram_private_api/endpoints/live.py
+++ b/instagram_private_api/endpoints/live.py
@@ -25,7 +25,7 @@ class LiveEndpointsMixin(object):
         if not (1 <= like_count <= 5):
             raise ValueError('Invalid like_count')
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/like/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/like/'.format(**{'broadcast_id': broadcast_id})
         params = {'user_like_count': str(like_count)}
         params.update(self.authenticated_params)
         return self._call_api(endpoint, params=params)
@@ -38,7 +38,7 @@ class LiveEndpointsMixin(object):
         :return:
         """
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/get_like_count/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/get_like_count/'.format(**{'broadcast_id': broadcast_id})
         return self._call_api(endpoint, query={'like_ts': like_ts})
 
     def broadcast_comments(self, broadcast_id, last_comment_ts=0):
@@ -50,7 +50,7 @@ class LiveEndpointsMixin(object):
         :return:
         """
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/get_comment/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/get_comment/'.format(**{'broadcast_id': broadcast_id})
         res = self._call_api(endpoint, query={'last_comment_ts': last_comment_ts})
         if self.auto_patch and res.get('comments'):
             [ClientCompatPatch.comment(c) for c in res.get('comments', [])]
@@ -66,7 +66,7 @@ class LiveEndpointsMixin(object):
         :return:
         """
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/heartbeat_and_get_viewer_count/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/heartbeat_and_get_viewer_count/'.format(**{'broadcast_id': broadcast_id})
         params = {
             '_csrftoken': self.csrftoken,
             '_uuid': self.uuid
@@ -82,7 +82,7 @@ class LiveEndpointsMixin(object):
         :return:
         """
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/comment/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/comment/'.format(**{'broadcast_id': broadcast_id})
         params = {
             'live_or_vod': '1',
             'offset_to_video_start': '0',
@@ -137,7 +137,7 @@ class LiveEndpointsMixin(object):
                 }
         """
         broadcast_id = str(broadcast_id)
-        endpoint = 'live/%(broadcast_id)s/info/' % {'broadcast_id': broadcast_id}
+        endpoint = 'live/{broadcast_id!s}/info/'.format(**{'broadcast_id': broadcast_id})
         return self._call_api(endpoint)
 
     def suggested_broadcasts(self, **kwargs):

--- a/instagram_private_api/endpoints/locations.py
+++ b/instagram_private_api/endpoints/locations.py
@@ -26,7 +26,7 @@ class LocationsEndpointsMixin(object):
                   }
                 }
         """
-        endpoint = 'locations/%(location_id)s/info/' % {'location_id': location_id}
+        endpoint = 'locations/{location_id!s}/info/'.format(**{'location_id': location_id})
         return self._call_api(endpoint)
 
     def location_related(self, location_id, **kwargs):
@@ -36,7 +36,7 @@ class LocationsEndpointsMixin(object):
         :param location_id:
         :return:
         """
-        endpoint = 'locations/%(location_id)s/related/' % {'location_id': location_id}
+        endpoint = 'locations/{location_id!s}/related/'.format(**{'location_id': location_id})
         query = {
             'visited': json.dumps([{'id': location_id, 'type': 'location'}], separators=(',', ':')),
             'related_types': json.dumps(['location'], separators=(',', ':'))}

--- a/instagram_private_api/endpoints/media.py
+++ b/instagram_private_api/endpoints/media.py
@@ -17,7 +17,7 @@ class MediaEndpointsMixin(object):
         :param media_id:
         :return:
         """
-        endpoint = 'media/%(media_id)s/info/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/info/'.format(**{'media_id': media_id})
         res = self._call_api(endpoint)
         if self.auto_patch:
             [ClientCompatPatch.media(m, drop_incompat_keys=self.drop_incompat_keys)
@@ -55,7 +55,7 @@ class MediaEndpointsMixin(object):
         :param media_id:
         :return:
         """
-        endpoint = 'media/%(media_id)s/permalink/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/permalink/'.format(**{'media_id': media_id})
         res = self._call_api(endpoint)
         return res
 
@@ -68,7 +68,7 @@ class MediaEndpointsMixin(object):
             **max_id**: For pagination
         :return:
         """
-        endpoint = 'media/%(media_id)s/comments/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/comments/'.format(**{'media_id': media_id})
         res = self._call_api(endpoint, query=kwargs)
 
         if self.auto_patch:
@@ -87,7 +87,7 @@ class MediaEndpointsMixin(object):
         :return:
         """
 
-        endpoint = 'media/%(media_id)s/comments/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/comments/'.format(**{'media_id': media_id})
 
         comments = []
         results = self._call_api(endpoint, query=kwargs)
@@ -123,7 +123,7 @@ class MediaEndpointsMixin(object):
         """
         if usertags is None:
             usertags = []
-        endpoint = 'media/%(media_id)s/edit_media/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/edit_media/'.format(**{'media_id': media_id})
         params = {'caption_text': caption}
         params.update(self.authenticated_params)
         if usertags:
@@ -144,7 +144,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok", "did_delete": true}
         """
-        endpoint = 'media/%(media_id)s/delete/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/delete/'.format(**{'media_id': media_id})
         params = {'media_id': media_id}
         params.update(self.authenticated_params)
         return self._call_api(endpoint, params=params)
@@ -192,7 +192,7 @@ class MediaEndpointsMixin(object):
         if len(re.findall(r'\bhttps?://\S+\.\S+', comment_text)) > 1:
             raise ValueError('The comment cannot contain more than 1 URL.')
 
-        endpoint = 'media/%(media_id)s/comment/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/comment/'.format(**{'media_id': media_id})
         params = {
             'comment_text': comment_text,
             'user_breadcrumb': gen_user_breadcrumb(len(comment_text)),
@@ -217,8 +217,8 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/comment/%(comment_id)s/delete/' % {
-            'media_id': media_id, 'comment_id': comment_id}
+        endpoint = 'media/{media_id!s}/comment/{comment_id!s}/delete/'.format(**{
+            'media_id': media_id, 'comment_id': comment_id})
         params = {}
         params.update(self.authenticated_params)
         res = self._call_api(endpoint, params=params)
@@ -237,8 +237,8 @@ class MediaEndpointsMixin(object):
         """
         if not isinstance(comment_ids, list):
             comment_ids = [comment_ids]
-        endpoint = 'media/%(media_id)s/comment/bulk_delete/' % {
-            'media_id': media_id}
+        endpoint = 'media/{media_id!s}/comment/bulk_delete/'.format(**{
+            'media_id': media_id})
         params = {
             'comment_ids_to_delete': ','.join(
                 [str(comment_id) for comment_id in comment_ids])
@@ -254,7 +254,7 @@ class MediaEndpointsMixin(object):
         :param media_id:
         :return:
         """
-        endpoint = 'media/%(media_id)s/likers/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/likers/'.format(**{'media_id': media_id})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             [ClientCompatPatch.list_user(u, drop_incompat_keys=self.drop_incompat_keys)
@@ -270,7 +270,7 @@ class MediaEndpointsMixin(object):
         :return:
         """
         warnings.warn('This endpoint is experimental. Do not use.', UserWarning)
-        res = self._call_api('media/%(media_id)s/likers_chrono/' % {'media_id': media_id})
+        res = self._call_api('media/{media_id!s}/likers_chrono/'.format(**{'media_id': media_id}))
         if self.auto_patch:
             [ClientCompatPatch.list_user(u, drop_incompat_keys=self.drop_incompat_keys)
              for u in res.get('users', [])]
@@ -287,7 +287,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/like/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/like/'.format(**{'media_id': media_id})
         params = {
             'media_id': media_id,
             'module_name': module_name,
@@ -309,7 +309,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/unlike/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/unlike/'.format(**{'media_id': media_id})
         params = {
             'media_id': media_id,
             'module_name': module_name,
@@ -350,7 +350,7 @@ class MediaEndpointsMixin(object):
             now = int(time.time())
             for i, reel in enumerate(reels):
                 reel_seen_at = now - min(i + 1 + randint(0, 2), max(0, now - reel['taken_at']))
-                reels_seen['%s_%s' % (reel['id'], reel['user']['pk'])] = ['%s_%s' % (reel['taken_at'], reel_seen_at)]
+                reels_seen['{0!s}_{1!s}'.format(reel['id'], reel['user']['pk'])] = ['{0!s}_{1!s}'.format(reel['taken_at'], reel_seen_at)]
             params = {'reels': reels_seen}
         else:
             params = {'reels': reels}
@@ -369,7 +369,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(comment_id)s/comment_like/' % {'comment_id': comment_id}
+        endpoint = 'media/{comment_id!s}/comment_like/'.format(**{'comment_id': comment_id})
         params = self.authenticated_params
         return self._call_api(endpoint, params=params)
 
@@ -380,7 +380,7 @@ class MediaEndpointsMixin(object):
         :param comment_id:
         :return:
         """
-        endpoint = 'media/%(comment_id)s/comment_likers/' % {'comment_id': comment_id}
+        endpoint = 'media/{comment_id!s}/comment_likers/'.format(**{'comment_id': comment_id})
         res = self._call_api(endpoint)
         if self.auto_patch:
             [ClientCompatPatch.list_user(u, drop_incompat_keys=self.drop_incompat_keys)
@@ -397,7 +397,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(comment_id)s/comment_unlike/' % {'comment_id': comment_id}
+        endpoint = 'media/{comment_id!s}/comment_unlike/'.format(**{'comment_id': comment_id})
         params = self.authenticated_params
         return self._call_api(endpoint, params=params)
 
@@ -412,7 +412,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/save/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/save/'.format(**{'media_id': media_id})
         params = {'radio_type': self.radio_type}
         if added_collection_ids:
             if isinstance(added_collection_ids, str):
@@ -432,7 +432,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/unsave/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/unsave/'.format(**{'media_id': media_id})
         params = {'radio_type': self.radio_type}
         if removed_collection_ids:
             if isinstance(removed_collection_ids, str):
@@ -451,7 +451,7 @@ class MediaEndpointsMixin(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'media/%(media_id)s/disable_comments/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/disable_comments/'.format(**{'media_id': media_id})
         params = {
             '_csrftoken': self.csrftoken,
             '_uuid': self.uuid,
@@ -470,7 +470,7 @@ class MediaEndpointsMixin(object):
                 {"status": "ok"}
         """
 
-        endpoint = 'media/%(media_id)s/enable_comments/' % {'media_id': media_id}
+        endpoint = 'media/{media_id!s}/enable_comments/'.format(**{'media_id': media_id})
         params = {
             '_csrftoken': self.csrftoken,
             '_uuid': self.uuid,

--- a/instagram_private_api/endpoints/misc.py
+++ b/instagram_private_api/endpoints/misc.py
@@ -141,7 +141,7 @@ class MiscEndpointsMixin(object):
         :return:
         """
         if sticker_type not in ['static_stickers']:
-            raise ValueError('Invalid sticker_type: %s' % sticker_type)
+            raise ValueError('Invalid sticker_type: {0!s}'.format(sticker_type))
         if location and not ('lat' in location and 'lng' in location and 'horizontalAccuracy' in location):
             raise ValueError('Invalid location')
         params = {

--- a/instagram_private_api/endpoints/tags.py
+++ b/instagram_private_api/endpoints/tags.py
@@ -10,7 +10,7 @@ class TagsEndpointsMixin(object):
         :param tag:
         :return:
         """
-        endpoint = 'tags/%(tag)s/info/' % {'tag': tag}
+        endpoint = 'tags/{tag!s}/info/'.format(**{'tag': tag})
         res = self._call_api(endpoint)
         return res
 
@@ -21,7 +21,7 @@ class TagsEndpointsMixin(object):
         :param tag:
         :return:
         """
-        endpoint = 'tags/%(tag)s/related/' % {'tag': tag}
+        endpoint = 'tags/{tag!s}/related/'.format(**{'tag': tag})
         query = {
             'visited': json.dumps([{'id': tag, 'type': 'hashtag'}], separators=(',', ':')),
             'related_types': json.dumps(['hashtag'], separators=(',', ':'))}

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -32,10 +32,10 @@ class UploadEndpointsMixin(object):
                 location[self.EXTERNAL_LOC_SOURCES[external_source]] = location['external_id']
         for k in location_keys:
             if not location.get(k):
-                raise ValueError('Location dict must contain "%s".' % k)
+                raise ValueError('Location dict must contain "{0!s}".'.format(k))
         for k, val in self.EXTERNAL_LOC_SOURCES.items():
             if location['external_source'] == k and not location.get(val):
-                raise ValueError('Location dict must contain "%s".' % val)
+                raise ValueError('Location dict must contain "{0!s}".'.format(val))
 
         media_loc = {
             'name': location['name'],
@@ -387,7 +387,7 @@ class UploadEndpointsMixin(object):
                 fields.append(('media_type', '2'))
 
         files = [
-            ('photo', 'pending_media_%s%s' % (str(int(time.time() * 1000)), '.jpg'),
+            ('photo', 'pending_media_{0!s}{1!s}'.format(str(int(time.time() * 1000)), '.jpg'),
              'application/octet-stream', photo_data)
         ]
 
@@ -398,23 +398,23 @@ class UploadEndpointsMixin(object):
 
         req = compat_urllib_request.Request(self.api_url + endpoint, body, headers=headers)
         try:
-            self.logger.debug('POST %s' % self.api_url + endpoint)
+            self.logger.debug('POST {0!s}'.format(self.api_url) + endpoint)
             response = self.opener.open(req, timeout=self.timeout)
         except compat_urllib_error.HTTPError as e:
             error_msg = e.reason
             error_response = self._read_response(e)
-            self.logger.debug('RESPONSE: %d %s' % (e.code, error_response))
+            self.logger.debug('RESPONSE: {0:d} {1!s}'.format(e.code, error_response))
             try:
                 error_obj = json.loads(error_response)
                 if error_obj.get('message'):
-                    error_msg = '%s: %s' % (e.reason, error_obj['message'])
+                    error_msg = '{0!s}: {1!s}'.format(e.reason, error_obj['message'])
             except:
                 # do nothing, prob can't parse json
                 pass
             raise ClientError(error_msg, e.code, error_response)
 
         post_response = self._read_response(response)
-        self.logger.debug('RESPONSE: %d %s' % (response.code, post_response))
+        self.logger.debug('RESPONSE: {0:d} {1!s}'.format(response.code, post_response))
         json_response = json.loads(post_response)
 
         if for_video and is_sidecar:
@@ -533,7 +533,7 @@ class UploadEndpointsMixin(object):
                         skip_chunk = True
                         break
                 if skip_chunk:
-                    self.logger.debug('Skipped chunk: %d - %d' % (chunk.start, chunk.end - 1))
+                    self.logger.debug('Skipped chunk: {0:d} - {1:d}'.format(chunk.start, chunk.end - 1))
                     continue
 
                 # data = video_data[chunk.start: chunk.end]
@@ -546,9 +546,9 @@ class UploadEndpointsMixin(object):
                     headers['Cookie'] = 'sessionid=' + self.get_cookie_value('sessionid')
                 headers['job'] = upload_job
                 headers['Content-Length'] = chunk.length
-                headers['Content-Range'] = 'bytes %d-%d/%d' % (chunk.start, chunk.end - 1, video_file_len)
-                self.logger.debug('POST %s' % upload_url)
-                self.logger.debug('Uploading Content-Range: %s' % headers['Content-Range'])
+                headers['Content-Range'] = 'bytes {0:d}-{1:d}/{2:d}'.format(chunk.start, chunk.end - 1, video_file_len)
+                self.logger.debug('POST {0!s}'.format(upload_url))
+                self.logger.debug('Uploading Content-Range: {0!s}'.format(headers['Content-Range']))
 
                 req = compat_urllib_request.Request(
                     str(upload_url), data=data, headers=headers)
@@ -556,7 +556,7 @@ class UploadEndpointsMixin(object):
                 try:
                     res = self.opener.open(req, timeout=self.timeout)
                     post_response = self._read_response(res)
-                    self.logger.debug('RESPONSE: %d %s' % (res.code, post_response))
+                    self.logger.debug('RESPONSE: {0:d} {1!s}'.format(res.code, post_response))
                     if res.info().get('Content-Type') == 'application/json':
                         # last chunk
                         upload_res = json.loads(post_response)
@@ -571,19 +571,19 @@ class UploadEndpointsMixin(object):
                             if mobj:
                                 successful_chunk_ranges.append((int(mobj.group('start')), int(mobj.group('end'))))
                             else:
-                                self.logger.error('Received unexpected chunk upload response: %s' % post_response)
+                                self.logger.error('Received unexpected chunk upload response: {0!s}'.format(post_response))
                                 raise ClientError(
-                                    'Upload has failed due to unexpected upload response: %s' % post_response,
+                                    'Upload has failed due to unexpected upload response: {0!s}'.format(post_response),
                                     code=500)
 
                 except compat_urllib_error.HTTPError as e:
                     error_msg = e.reason
                     error_response = self._read_response(e)
-                    self.logger.debug('RESPONSE: %d %s' % (e.code, error_response))
+                    self.logger.debug('RESPONSE: {0:d} {1!s}'.format(e.code, error_response))
                     try:
                         error_obj = json.loads(error_response)
                         if error_obj.get('message'):
-                            error_msg = '%s: %s' % (e.reason, error_obj['message'])
+                            error_msg = '{0!s}: {1!s}'.format(e.reason, error_obj['message'])
                     except:
                         # do nothing, prob can't parse json
                         pass
@@ -613,7 +613,7 @@ class UploadEndpointsMixin(object):
                 return result
             except ClientError as ce:
                 if (ce.code == 202 or ce.msg == 'Transcode timeout') and i < configure_retry_max:
-                    self.logger.warn('Retry configure after %f seconds' % configure_delay)
+                    self.logger.warn('Retry configure after {0:f} seconds'.format(configure_delay))
                     time.sleep(configure_delay)
                 else:
                     raise
@@ -671,7 +671,7 @@ class UploadEndpointsMixin(object):
             if len(children_metadata) >= 10:
                 continue
             if media.get('type', '') not in ['image', 'video']:
-                raise ValueError('Invalid media type: %s' % media.get('type', ''))
+                raise ValueError('Invalid media type: {0!s}'.format(media.get('type', '')))
             if not media.get('data'):
                 raise ValueError('Data not specified.')
             if not media.get('size'):
@@ -706,7 +706,7 @@ class UploadEndpointsMixin(object):
             children_metadata.append(metadata)
 
         if len(children_metadata) <= 1:
-            raise ValueError('Invalid number of media objects: %d' % len(children_metadata))
+            raise ValueError('Invalid number of media objects: {0:d}'.format(len(children_metadata)))
 
         # configure as sidecar
         endpoint = 'media/configure_sidecar/'

--- a/instagram_private_api/endpoints/users.py
+++ b/instagram_private_api/endpoints/users.py
@@ -12,7 +12,7 @@ class UsersEndpointsMixin(object):
         :param user_id:
         :return:
         """
-        res = self._call_api('users/%(user_id)s/info/' % {'user_id': user_id})
+        res = self._call_api('users/{user_id!s}/info/'.format(**{'user_id': user_id}))
         if self.auto_patch:
             ClientCompatPatch.user(res['user'], drop_incompat_keys=self.drop_incompat_keys)
         return res
@@ -23,7 +23,7 @@ class UsersEndpointsMixin(object):
         :param user_name:
         :return:
         """
-        res = self._call_api('users/%(user_name)s/usernameinfo/' % {'user_name': user_name})
+        res = self._call_api('users/{user_name!s}/usernameinfo/'.format(**{'user_name': user_name}))
         if self.auto_patch:
             ClientCompatPatch.user(res['user'], drop_incompat_keys=self.drop_incompat_keys)
         return res
@@ -41,7 +41,7 @@ class UsersEndpointsMixin(object):
         """
         warnings.warn('This endpoint is experimental. Do not use.', UserWarning)
 
-        endpoint = 'users/%(user_id)s/full_detail_info/' % {'user_id': user_id}
+        endpoint = 'users/{user_id!s}/full_detail_info/'.format(**{'user_id': user_id})
         res = self._call_api(endpoint, query=kwargs)
         if self.auto_patch:
             ClientCompatPatch.user(res['user_detail']['user'], drop_incompat_keys=self.drop_incompat_keys)
@@ -60,7 +60,7 @@ class UsersEndpointsMixin(object):
         :param user_id: User id
         :return:
         """
-        endpoint = 'maps/user/%(user_id)s/' % {'user_id': user_id}
+        endpoint = 'maps/user/{user_id!s}/'.format(**{'user_id': user_id})
         return self._call_api(endpoint)
 
     def search_users(self, query, **kwargs):
@@ -135,7 +135,7 @@ class UsersEndpointsMixin(object):
                 }
         """
         if message_prefs not in ['anyone', 'following', 'off']:
-            raise ValueError('Invalid message_prefs: %s' % message_prefs)
+            raise ValueError('Invalid message_prefs: {0!s}'.format(message_prefs))
         params = {'message_prefs': message_prefs}
         params.update(self.authenticated_params)
         return self._call_api('users/set_reel_settings/', params=params)

--- a/instagram_private_api/endpoints/usertags.py
+++ b/instagram_private_api/endpoints/usertags.py
@@ -11,7 +11,7 @@ class UsertagsEndpointsMixin(object):
         :param kwargs:
         :return:
         """
-        endpoint = 'usertags/%(user_id)s/feed/' % {'user_id': user_id}
+        endpoint = 'usertags/{user_id!s}/feed/'.format(**{'user_id': user_id})
         query = {'rank_token': self.rank_token, 'ranked_content': 'true'}
         query.update(kwargs)
         res = self._call_api(endpoint, query=query)
@@ -27,7 +27,7 @@ class UsertagsEndpointsMixin(object):
         :param media_id: Media id
         :return:
         """
-        endpoint = 'usertags/%(media_id)s/remove/' % {'media_id': media_id}
+        endpoint = 'usertags/{media_id!s}/remove/'.format(**{'media_id': media_id})
         res = self._call_api(endpoint, params=self.authenticated_params)
         if self.auto_patch:
             ClientCompatPatch.media(res.get('media'))

--- a/instagram_private_api/utils.py
+++ b/instagram_private_api/utils.py
@@ -15,10 +15,10 @@ def gen_user_breadcrumb(size):
 
     text_change_event_count = max(1, size / randint(3, 5))
 
-    data = '%(size)s %(elapsed)s %(count)s %(dt)s' % {
+    data = '{size!s} {elapsed!s} {count!s} {dt!s}'.format(**{
         'size': size, 'elapsed': time_elapsed, 'count': text_change_event_count, 'dt': dt
-    }
-    return '%s\n%s\n' % (
+    })
+    return '{0!s}\n{1!s}\n'.format(
         base64.b64encode(hmac.new(key.encode('ascii'), data.encode('ascii'), digestmod=hashlib.sha256).digest()),
         base64.b64encode(data.encode('ascii')))
 
@@ -157,7 +157,7 @@ class InstagramID:
         :param media_id:
         :return:
         """
-        return 'https://www.instagram.com/p/%s/' % cls.shorten_media_id(media_id)
+        return 'https://www.instagram.com/p/{0!s}/'.format(cls.shorten_media_id(media_id))
 
     @classmethod
     def shorten_media_id(cls, media_id):

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -67,7 +67,7 @@ class Client(object):
         cookie_string = kwargs.pop('cookie', None) or user_settings.get('cookie')
         cookie_jar = ClientCookieJar(cookie_string=cookie_string)
         if cookie_string and cookie_jar.expires_earliest and int(time.time()) >= cookie_jar.expires_earliest:
-            raise ClientCookieExpiredError('Oldest cookie expired at %s' % cookie_jar.expires_earliest)
+            raise ClientCookieExpiredError('Oldest cookie expired at {0!s}'.format(cookie_jar.expires_earliest))
 
         custom_ssl_context = kwargs.pop('custom_ssl_context', None)
         proxy_handler = None
@@ -76,10 +76,10 @@ class Client(object):
             warnings.warn('Proxy support is alpha.', UserWarning)
             parsed_url = compat_urllib_parse_urlparse(proxy)
             if parsed_url.netloc and parsed_url.scheme:
-                proxy_address = '%s://%s' % (parsed_url.scheme, parsed_url.netloc)
+                proxy_address = '{0!s}://{1!s}'.format(parsed_url.scheme, parsed_url.netloc)
                 proxy_handler = compat_urllib_request.ProxyHandler({'https': proxy_address})
             else:
-                raise ValueError('Invalid proxy argument: %s' % proxy)
+                raise ValueError('Invalid proxy argument: {0!s}'.format(proxy))
         handlers = []
         if proxy_handler:
             handlers.append(proxy_handler)
@@ -178,8 +178,8 @@ class Client(object):
             else:
                 data = compat_urllib_parse.urlencode(params).encode('ascii')
         try:
-            self.logger.debug('REQUEST: %s %s' % (url, req.get_method()))
-            self.logger.debug('DATA: %s' % data)
+            self.logger.debug('REQUEST: {0!s} {1!s}'.format(url, req.get_method()))
+            self.logger.debug('DATA: {0!s}'.format(data))
             res = self.opener.open(req, data=data, timeout=self.timeout)
             if return_response:
                 return res
@@ -190,13 +190,13 @@ class Client(object):
             else:
                 response_content = res.read().decode('utf8')
 
-            self.logger.debug('RESPONSE: %s' % response_content)
+            self.logger.debug('RESPONSE: {0!s}'.format(response_content))
             return json.loads(response_content)
 
         except compat_urllib_error.HTTPError as e:
-            raise ClientError('HTTPError "%s" while opening %s' % (e.reason, url), e.code)
+            raise ClientError('HTTPError "{0!s}" while opening {1!s}'.format(e.reason, url), e.code)
         except compat_urllib_error.URLError as e:
-            raise ClientError('URLError "%s" while opening %s' % (e.reason, url))
+            raise ClientError('URLError "{0!s}" while opening {1!s}'.format(e.reason, url))
 
     def _sanitise_media_id(self, media_id):
         """The web API uses the numeric media ID only, and not the formatted one where it's XXXXX_YYY"""
@@ -261,9 +261,9 @@ class Client(object):
         count = kwargs.pop('count', 16)
         min_media_id = kwargs.pop('min_media_id', None) or kwargs.pop('end_cursor', None)
         if not min_media_id:
-            command = 'media.first(%(count)d)' % {'count': count}
+            command = 'media.first({count:d})'.format(**{'count': count})
         else:
-            command = 'media.after(%(min_id)s, %(count)d)' % {'count': count, 'min_id': min_media_id}
+            command = 'media.after({min_id!s}, {count:d})'.format(**{'count': count, 'min_id': min_media_id})
         params = {
             'q': 'ig_user(%(user_id)s) {%(command)s {count, nodes {'
                  'caption, code, comments {count}, date, dimensions {height, width}, comments_disabled, '
@@ -332,7 +332,7 @@ class Client(object):
             'x-requested-with': 'XMLHttpRequest',
         }
         info = self._make_request(
-            'https://www.instagram.com/p/%s/?__a=1&__b=1' % short_code,
+            'https://www.instagram.com/p/{0!s}/?__a=1&__b=1'.format(short_code),
             headers=headers)
         media = info.get('graphql', {}).get('shortcode_media', {})
         if self.auto_patch:
@@ -455,7 +455,7 @@ class Client(object):
                 {"status": "ok"}
         """
         media_id = self._sanitise_media_id(media_id)
-        endpoint = 'https://www.instagram.com/web/likes/%(media_id)s/like/' % {'media_id': media_id}
+        endpoint = 'https://www.instagram.com/web/likes/{media_id!s}/like/'.format(**{'media_id': media_id})
         res = self._make_request(endpoint, params='')
         return res
 
@@ -471,7 +471,7 @@ class Client(object):
                 {"status": "ok"}
         """
         media_id = self._sanitise_media_id(media_id)
-        endpoint = 'https://www.instagram.com/web/likes/%(media_id)s/unlike/' % {'media_id': media_id}
+        endpoint = 'https://www.instagram.com/web/likes/{media_id!s}/unlike/'.format(**{'media_id': media_id})
         return self._make_request(endpoint, params='')
 
     @login_required
@@ -485,7 +485,7 @@ class Client(object):
 
                 {"status": "ok", "result": "following"}
         """
-        endpoint = 'https://www.instagram.com/web/friendships/%(user_id)s/follow/' % {'user_id': user_id}
+        endpoint = 'https://www.instagram.com/web/friendships/{user_id!s}/follow/'.format(**{'user_id': user_id})
         return self._make_request(endpoint, params='')
 
     @login_required
@@ -499,7 +499,7 @@ class Client(object):
 
                 {"status": "ok"}
         """
-        endpoint = 'https://www.instagram.com/web/friendships/%(user_id)s/unfollow/' % {'user_id': user_id}
+        endpoint = 'https://www.instagram.com/web/friendships/{user_id!s}/unfollow/'.format(**{'user_id': user_id})
         return self._make_request(endpoint, params='')
 
     @login_required
@@ -535,7 +535,7 @@ class Client(object):
             raise ValueError('The comment cannot contain more than 1 URL.')
 
         media_id = self._sanitise_media_id(media_id)
-        endpoint = 'https://www.instagram.com/web/comments/%(media_id)s/add/' % {'media_id': media_id}
+        endpoint = 'https://www.instagram.com/web/comments/{media_id!s}/add/'.format(**{'media_id': media_id})
         params = {'comment_text': comment_text}
         return self._make_request(endpoint, params=params)
 
@@ -552,8 +552,8 @@ class Client(object):
                 {"status": "ok"}
         """
         media_id = self._sanitise_media_id(media_id)
-        endpoint = 'https://www.instagram.com/web/comments/%(media_id)s/delete/%(comment_id)s/' % {
-            'media_id': media_id, 'comment_id': comment_id}
+        endpoint = 'https://www.instagram.com/web/comments/{media_id!s}/delete/{comment_id!s}/'.format(**{
+            'media_id': media_id, 'comment_id': comment_id})
         return self._make_request(endpoint, params='')
 
     def search(self, query_text):

--- a/instagram_web_api/compatpatch.py
+++ b/instagram_web_api/compatpatch.py
@@ -14,9 +14,9 @@ class ClientCompatPatch():
     def _generate_image_url(cls, url, size, crop):
         mobj = re.search(cls.IG_IMAGE_URL_EXPR, url)
         if not mobj:
-            replacement_expr = '\g<eparam>%(crop)s%(size)sx%(size)s/' % {'crop': crop, 'size': size}
+            replacement_expr = '\g<eparam>{crop!s}{size!s}x{size!s}/'.format(**{'crop': crop, 'size': size})
             return re.sub(r'(?P<eparam>/e[0-9]+/)', replacement_expr, url)
-        replacement_expr = '/%(crop)s%(size)sx%(size)s/' % {'crop': mobj.group('crop') or crop, 'size': size}
+        replacement_expr = '/{crop!s}{size!s}x{size!s}/'.format(**{'crop': mobj.group('crop') or crop, 'size': size})
         return re.sub(cls.IG_IMAGE_URL_EXPR, replacement_expr, url)
 
     @classmethod
@@ -29,8 +29,8 @@ class ClientCompatPatch():
     @classmethod
     def media(cls, media, drop_incompat_keys=False):
         """Patch a media object"""
-        media['link'] = 'https://www.instagram.com/p/%s/' % (
-            media.get('code') or media.get('shortcode'))   # for media_info2
+        media['link'] = 'https://www.instagram.com/p/{0!s}/'.format((
+            media.get('code') or media.get('shortcode')))   # for media_info2
         caption = media.get('caption')
         if not caption:
             media['caption'] = None
@@ -84,7 +84,7 @@ class ClientCompatPatch():
         else:
             media['location']['latitude'] = media['location']['lat']
             media['location']['longitude'] = media['location']['lng']
-        media['id'] = '%s_%s' % (media['id'], media['owner']['id'])
+        media['id'] = '{0!s}_{1!s}'.format(media['id'], media['owner']['id'])
         media['created_time'] = str(media.get('date', '') or media.get('taken_at_timestamp', ''))
 
         usertags = media.get('usertags', {}).get('nodes', [])
@@ -125,7 +125,7 @@ class ClientCompatPatch():
                     node['videos'] = videos
                     node['type'] = 'video'
                 node['pk'] = node['id']
-                node['id'] = '%s_%s' % (node['id'], media['owner']['id'])
+                node['id'] = '{0!s}_{1!s}'.format(node['id'], media['owner']['id'])
                 node['original_width'] = node['dimensions']['width']
                 node['original_height'] = node['dimensions']['height']
                 carousel_media.append(node)

--- a/misc/checkpoint.py
+++ b/misc/checkpoint.py
@@ -52,9 +52,9 @@ class Checkpoint:
         cookie_val = res.info().get('set-cookie') or ''
         cookie = ''
         for c in ['sessionid', 'checkpoint_step', 'mid', 'csrftoken']:
-            cookie_mobj = re.search(r'%s=(?P<val>[^;]+?);' % c, cookie_val)
+            cookie_mobj = re.search(r'{0!s}=(?P<val>[^;]+?);'.format(c), cookie_val)
             if cookie_mobj:
-                cookie += '%s=%s; ' % (c, unquote_plus(cookie_mobj.group('val')))
+                cookie += '{0!s}={1!s}; '.format(c, unquote_plus(cookie_mobj.group('val')))
 
         self.cookie = cookie
         data = {'csrfmiddlewaretoken': csrf, 'email': 'Verify by Email'}    # 'sms': 'Verify by SMS'
@@ -132,4 +132,4 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         sys.exit(0)
     except Exception as e:
-        print('Unexpected error: %s' % str(e))
+        print('Unexpected error: {0!s}'.format(str(e)))

--- a/tests/private/accounts.py
+++ b/tests/private/accounts.py
@@ -347,7 +347,7 @@ class AccountTests(ApiTestBase):
             signed_body = hash_sig + '.' + json_params
             headers = self.api.default_headers
             headers.update({
-                'Content-Type': 'multipart/form-data; boundary=%s' % self.api.uuid,
+                'Content-Type': 'multipart/form-data; boundary={0!s}'.format(self.api.uuid),
                 'Content-Length': len(photo_data)
             })
             body = '--%(uuid)s\r\n' \

--- a/tests/private/collections.py
+++ b/tests/private/collections.py
@@ -101,11 +101,11 @@ class CollectionsTests(ApiTestBase):
 
         self.api.edit_collection(collection_id, media_ids)
         call_api.assert_called_with(
-            'collections/%(collection_id)s/edit/' % {'collection_id': collection_id},
+            'collections/{collection_id!s}/edit/'.format(**{'collection_id': collection_id}),
             params=params)
         self.api.edit_collection(collection_id, media_ids[0])
         call_api.assert_called_with(
-            'collections/%(collection_id)s/edit/' % {'collection_id': collection_id},
+            'collections/{collection_id!s}/edit/'.format(**{'collection_id': collection_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -124,5 +124,5 @@ class CollectionsTests(ApiTestBase):
 
         self.api.delete_collection(collection_id)
         call_api.assert_called_with(
-            'collections/%(collection_id)s/delete/' % {'collection_id': collection_id},
+            'collections/{collection_id!s}/delete/'.format(**{'collection_id': collection_id}),
             params=self.api.authenticated_params)

--- a/tests/private/friendships.py
+++ b/tests/private/friendships.py
@@ -146,7 +146,7 @@ class FriendshipTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.friendships_create(user_id)
         call_api.assert_called_with(
-            'friendships/create/%(user_id)s/' % {'user_id': user_id},
+            'friendships/create/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -163,7 +163,7 @@ class FriendshipTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.friendships_destroy(user_id)
         call_api.assert_called_with(
-            'friendships/destroy/%(user_id)s/' % {'user_id': user_id},
+            'friendships/destroy/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -180,7 +180,7 @@ class FriendshipTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.friendships_block(user_id)
         call_api.assert_called_with(
-            'friendships/block/%(user_id)s/' % {'user_id': user_id},
+            'friendships/block/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -191,7 +191,7 @@ class FriendshipTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.friendships_unblock(user_id)
         call_api.assert_called_with(
-            'friendships/unblock/%(user_id)s/' % {'user_id': user_id},
+            'friendships/unblock/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
 
     def test_blocked_reels(self):
@@ -207,7 +207,7 @@ class FriendshipTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.block_friend_reel(user_id)
         call_api.assert_called_with(
-            'friendships/block_friend_reel/%(user_id)s/' % {'user_id': user_id},
+            'friendships/block_friend_reel/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -216,7 +216,7 @@ class FriendshipTests(ApiTestBase):
         user_id = '2958144170'
         self.api.unblock_friend_reel(user_id)
         call_api.assert_called_with(
-            'friendships/unblock_friend_reel/%(user_id)s/' % {'user_id': user_id},
+            'friendships/unblock_friend_reel/{user_id!s}/'.format(**{'user_id': user_id}),
             params=self.api.authenticated_params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')

--- a/tests/private/live.py
+++ b/tests/private/live.py
@@ -78,7 +78,7 @@ class LiveTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.broadcast_like(broadcast_id, like_count)
         call_api.assert_called_with(
-            'live/%(broadcast_id)s/like/' % {'broadcast_id': broadcast_id},
+            'live/{broadcast_id!s}/like/'.format(**{'broadcast_id': broadcast_id}),
             params=params)
 
     def test_broadcast_like_count(self):
@@ -152,7 +152,7 @@ class LiveTests(ApiTestBase):
             params.update(self.api.authenticated_params)
             self.api.broadcast_comment(broadcast_id, comment_text)
             call_api.assert_called_with(
-                'live/%(broadcast_id)s/comment/' % {'broadcast_id': broadcast_id},
+                'live/{broadcast_id!s}/comment/'.format(**{'broadcast_id': broadcast_id}),
                 params=params)
 
     def test_broadcast_info(self):

--- a/tests/private/media.py
+++ b/tests/private/media.py
@@ -222,7 +222,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.edit_media(media_id, 'Hello')
         call_api.assert_called_with(
-            'media/%(media_id)s/edit_media/' % {'media_id': media_id},
+            'media/{media_id!s}/edit_media/'.format(**{'media_id': media_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -240,7 +240,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.delete_media(media_id)
         call_api.assert_called_with(
-            'media/%(media_id)s/delete/' % {'media_id': media_id},
+            'media/{media_id!s}/delete/'.format(**{'media_id': media_id}),
             params=params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -269,7 +269,7 @@ class MediaTests(ApiTestBase):
             params.update(self.api.authenticated_params)
             self.api.post_comment(media_id, comment_text)
             call_api.assert_called_with(
-                'media/%(media_id)s/comment/' % {'media_id': media_id},
+                'media/{media_id!s}/comment/'.format(**{'media_id': media_id}),
                 params=params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -279,8 +279,7 @@ class MediaTests(ApiTestBase):
         comment_id = '123456'
         self.api.delete_comment(media_id, comment_id)
         call_api.assert_called_with(
-            'media/%(media_id)s/comment/%(comment_id)s/delete/'
-            % {'media_id': media_id, 'comment_id': comment_id},
+            'media/{media_id!s}/comment/{comment_id!s}/delete/'.format(**{'media_id': media_id, 'comment_id': comment_id}),
             params=self.api.authenticated_params)
 
     def test_media_likers(self):
@@ -310,7 +309,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.post_like(media_id, params['module_name'])
         call_api.assert_called_with(
-            'media/%(media_id)s/like/' % {'media_id': media_id},
+            'media/{media_id!s}/like/'.format(**{'media_id': media_id}),
             query={'d': '1'},
             params=params)
 
@@ -331,7 +330,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.delete_like(media_id, params['module_name'])
         call_api.assert_called_with(
-            'media/%(media_id)s/unlike/' % {'media_id': media_id},
+            'media/{media_id!s}/unlike/'.format(**{'media_id': media_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -345,7 +344,7 @@ class MediaTests(ApiTestBase):
         comment_id = '1785000000000'
         self.api.comment_like(comment_id)
         call_api.assert_called_with(
-            'media/%(comment_id)s/comment_like/' % {'comment_id': comment_id},
+            'media/{comment_id!s}/comment_like/'.format(**{'comment_id': comment_id}),
             params=self.api.authenticated_params)
 
     @unittest.skip('Modifies data.')
@@ -359,7 +358,7 @@ class MediaTests(ApiTestBase):
         comment_id = '1785000000000'
         self.api.comment_unlike(comment_id)
         call_api.assert_called_with(
-            'media/%(comment_id)s/comment_unlike/' % {'comment_id': comment_id},
+            'media/{comment_id!s}/comment_unlike/'.format(**{'comment_id': comment_id}),
             params=self.api.authenticated_params)
 
     def test_comment_likers(self):
@@ -383,7 +382,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.save_photo(self.test_media_id, added_collection_ids=added_collection_ids)
         call_api.assert_called_with(
-            'media/%(media_id)s/save/' % {'media_id': self.test_media_id},
+            'media/{media_id!s}/save/'.format(**{'media_id': self.test_media_id}),
             params=params)
 
     @unittest.skip('Modifies data.')
@@ -402,7 +401,7 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.unsave_photo(self.test_media_id, removed_collection_ids=removed_collection_ids)
         call_api.assert_called_with(
-            'media/%(media_id)s/unsave/' % {'media_id': self.test_media_id},
+            'media/{media_id!s}/unsave/'.format(**{'media_id': self.test_media_id}),
             params=params)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -414,7 +413,7 @@ class MediaTests(ApiTestBase):
         }
         self.api.disable_comments(self.test_media_id)
         call_api.assert_called_with(
-            'media/%(media_id)s/disable_comments/' % {'media_id': self.test_media_id},
+            'media/{media_id!s}/disable_comments/'.format(**{'media_id': self.test_media_id}),
             params=params, unsigned=True)
 
     @compat_mock.patch('instagram_private_api.Client._call_api')
@@ -426,7 +425,7 @@ class MediaTests(ApiTestBase):
         }
         self.api.enable_comments(self.test_media_id)
         call_api.assert_called_with(
-            'media/%(media_id)s/enable_comments/' % {'media_id': self.test_media_id},
+            'media/{media_id!s}/enable_comments/'.format(**{'media_id': self.test_media_id}),
             params=params, unsigned=True)
 
     @unittest.skip('Modifies data.')
@@ -463,8 +462,8 @@ class MediaTests(ApiTestBase):
             randint_mock.return_value = 0
             params = {
                 'reels': {
-                    '1309764653429046112_124317_124317': ['1470356135_%s' % (int(ts_now) - 1)],
-                    '1309209597843679372_124317_124317': ['1470289967_%s' % (int(ts_now) - 2)]},
+                    '1309764653429046112_124317_124317': ['1470356135_{0!s}'.format((int(ts_now) - 1))],
+                    '1309209597843679372_124317_124317': ['1470289967_{0!s}'.format((int(ts_now) - 2))]},
             }
             reels_params = [
                 {'id': '1309764653429046112_124317', 'taken_at': 1470356135, 'user': {'pk': 124317}},
@@ -486,6 +485,5 @@ class MediaTests(ApiTestBase):
         params.update(self.api.authenticated_params)
         self.api.bulk_delete_comments(media_id, comment_ids)
         call_api.assert_called_with(
-            'media/%(media_id)s/comment/bulk_delete/'
-            % {'media_id': media_id},
+            'media/{media_id!s}/comment/bulk_delete/'.format(**{'media_id': media_id}),
             params=params)

--- a/tests/private/upload.py
+++ b/tests/private/upload.py
@@ -205,7 +205,7 @@ class UploadTests(ApiTestBase):
             photo_data = '...'.encode('ascii')
             headers = self.api.default_headers
             headers.update({
-                'Content-Type': 'multipart/form-data; boundary=%s' % self.api.uuid,
+                'Content-Type': 'multipart/form-data; boundary={0!s}'.format(self.api.uuid),
                 'Content-Length': len(photo_data)
             })
             sidecar_fields = ''
@@ -456,7 +456,7 @@ class UploadTests(ApiTestBase):
             for i in range(chunk_count):
                 if i < (chunk_count - 1):
                     read_response_side_effect.append(
-                        '%d-%d/%d' % (chunk_size * i, chunk_size * (i + 1) - 1, video_data_len))
+                        '{0:d}-{1:d}/{2:d}'.format(chunk_size * i, chunk_size * (i + 1) - 1, video_data_len))
                 else:
                     read_response_side_effect.append(json.dumps({'status': 'ok'}))
 
@@ -511,7 +511,7 @@ class UploadTests(ApiTestBase):
                     headers['Cookie'] = 'sessionid=' + self.api.get_cookie_value('sessionid')
                 headers['job'] = '1111'
                 headers['Content-Length'] = chunk_size
-                headers['Content-Range'] = 'bytes %d-%d/%d' % (
+                headers['Content-Range'] = 'bytes {0:d}-{1:d}/{2:d}'.format(
                     i * chunk_size,
                     (i * chunk_size if i <= 3 else video_data_len) - 1,
                     video_data_len)

--- a/tests/private/usertags.py
+++ b/tests/private/usertags.py
@@ -50,5 +50,5 @@ class UsertagsTests(ApiTestBase):
         }
         self.api.usertag_self_remove(media_id)
         call_api.assert_called_with(
-            'usertags/%(media_id)s/remove/' % {'media_id': media_id},
+            'usertags/{media_id!s}/remove/'.format(**{'media_id': media_id}),
             params=self.api.authenticated_params)

--- a/tests/test_private_api.py
+++ b/tests/test_private_api.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    print('Client version: %s' % __version__)
+    print('Client version: {0!s}'.format(__version__))
 
     cached_auth = None
     if args.settings_file_path and os.path.isfile(args.settings_file_path):
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             # Example of how to generate a uuid.
             # You can generate a fixed uuid if you use a fixed value seed
             uuid = Client.generate_uuid(
-                seed='%(pw)s.%(usr)s.%(ts)s' % {'pw': args.username, 'usr': args.password, 'ts': ts_seed})
+                seed='{pw!s}.{usr!s}.{ts!s}'.format(**{'pw': args.username, 'usr': args.password, 'ts': ts_seed}))
         else:
             uuid = args.uuid
 
@@ -68,7 +68,7 @@ if __name__ == '__main__':
             # Example of how to generate a device id.
             # You can generate a fixed device id if you use a fixed value seed
             device_id = Client.generate_deviceid(
-                seed='%(usr)s.%(ts)s.%(pw)s' % {'pw': args.password, 'usr': args.username, 'ts': ts_seed})
+                seed='{usr!s}.{ts!s}.{pw!s}'.format(**{'pw': args.password, 'usr': args.username, 'ts': ts_seed}))
         else:
             device_id = args.device_id
 
@@ -147,7 +147,7 @@ if __name__ == '__main__':
 
     def match_regex(test_name):
         for test_re in args.tests:
-            test_re = r'%s' % test_re
+            test_re = r'{0!s}'.format(test_re)
             if re.match(test_re, test_name):
                 return True
         return False
@@ -162,4 +162,4 @@ if __name__ == '__main__':
         unittest.TextTestRunner(verbosity=2).run(suite)
 
     except ClientError as e:
-        print('Unexpected ClientError %s (Code: %d, Response: %s)' % (e.msg, e.code, e.error_response))
+        print('Unexpected ClientError {0!s} (Code: {1:d}, Response: {2!s})'.format(e.msg, e.code, e.error_response))

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    print('Client version: %s' % __version__)
+    print('Client version: {0!s}'.format(__version__))
 
     cached_auth = None
     if args.settings_file_path and os.path.isfile(args.settings_file_path):
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
     def match_regex(test_name):
         for test_re in args.tests:
-            test_re = r'%s' % test_re
+            test_re = r'{0!s}'.format(test_re)
             if re.match(test_re, test_name):
                 return True
         return False
@@ -111,4 +111,4 @@ if __name__ == '__main__':
         unittest.TextTestRunner(verbosity=2).run(suite)
 
     except ClientError as e:
-        print('Unexpected ClientError %s (Code: %d)' % (e.msg, e.code))
+        print('Unexpected ClientError {0!s} (Code: {1:d})'.format(e.msg, e.code))

--- a/tests/web/media.py
+++ b/tests/web/media.py
@@ -115,7 +115,7 @@ class MediaTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok', 'id': '12345678'}
         self.api.post_comment(self.test_media_id + '_12345', '<3')      # test sanitise media id
         make_request.assert_called_with(
-            'https://www.instagram.com/web/comments/%(media_id)s/add/' % {'media_id': self.test_media_id},
+            'https://www.instagram.com/web/comments/{media_id!s}/add/'.format(**{'media_id': self.test_media_id}),
             params={'comment_text': '<3'})
 
     @unittest.skip('Modifies data / Needs actual data.')
@@ -128,8 +128,7 @@ class MediaTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok'}
         self.api.delete_comment(self.test_media_id, self.test_comment_id)
         make_request.assert_called_with(
-            'https://www.instagram.com/web/comments/%(media_id)s/delete/%(comment_id)s/'
-            % {'media_id': self.test_media_id, 'comment_id': self.test_comment_id},
+            'https://www.instagram.com/web/comments/{media_id!s}/delete/{comment_id!s}/'.format(**{'media_id': self.test_media_id, 'comment_id': self.test_comment_id}),
             params='')
 
     @unittest.skip('Modifies data')
@@ -142,7 +141,7 @@ class MediaTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok'}
         self.api.post_like(self.test_media_id)
         make_request.assert_called_with(
-            'https://www.instagram.com/web/likes/%(media_id)s/like/' % {'media_id': self.test_media_id},
+            'https://www.instagram.com/web/likes/{media_id!s}/like/'.format(**{'media_id': self.test_media_id}),
             params='')
 
     @unittest.skip('Modifies data')
@@ -155,7 +154,7 @@ class MediaTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok'}
         self.api.delete_like(self.test_media_id)
         make_request.assert_called_with(
-            'https://www.instagram.com/web/likes/%(media_id)s/unlike/' % {'media_id': self.test_media_id},
+            'https://www.instagram.com/web/likes/{media_id!s}/unlike/'.format(**{'media_id': self.test_media_id}),
             params='')
 
     @compat_mock.patch('instagram_web_api.Client._make_request')

--- a/tests/web/user.py
+++ b/tests/web/user.py
@@ -132,7 +132,7 @@ class UserTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok'}
         self.api.friendships_create(self.test_user_id)
         make_request.assert_called_with(
-            'https://www.instagram.com/web/friendships/%(user_id)s/follow/' % {'user_id': self.test_user_id},
+            'https://www.instagram.com/web/friendships/{user_id!s}/follow/'.format(**{'user_id': self.test_user_id}),
             params='')
 
     @unittest.skip('Modifies data')
@@ -145,5 +145,5 @@ class UserTests(WebApiTestBase):
         make_request.return_value = {'status': 'ok'}
         self.api.friendships_destroy(self.test_user_id)
         make_request.assert_called_with(
-            'https://www.instagram.com/web/friendships/%(user_id)s/unfollow/' % {'user_id': self.test_user_id},
+            'https://www.instagram.com/web/friendships/{user_id!s}/unfollow/'.format(**{'user_id': self.test_user_id}),
             params='')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ping:instagram_private_api?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ping:instagram_private_api?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)