### PR TITLE
Support looking for media likes count under "edge_media_preview_like"

### DIFF
--- a/instagram_web_api/compatpatch.py
+++ b/instagram_web_api/compatpatch.py
@@ -102,7 +102,8 @@ class ClientCompatPatch(object):
             media['videos'] = videos
         media['likes'] = {
             'count': (media.get('likes', {})
-                      or media.get('edge_liked_by', {})).get('count', 0),
+                      or media.get('edge_liked_by', {})
+                      or media.get('edge_media_preview_like', {})).get('count', 0),
             'data': []
         }
         media['comments'] = {


### PR DESCRIPTION
## What does this PR do?

Small change that correctly retrieves the media like count in the web ClientCompatPatch when using an unauthenticated client.

## Why was this PR needed?

Media likes were not being returned (i.e. always 0) when using the compat patch on unauthenticated APIs.

## What are the relevant issue numbers?

#57 

## Does this PR meet the acceptance criteria?

- [x ] Passes flake8 (refer to ``.travis.yml``)
- [ x] Docs are buildable
- [ x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
