### PR TITLE
Use updated query hash to fetch extra info from UserFollowers

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -666,7 +666,7 @@ class Client(object):
             variables['after'] = end_cursor
 
         query = {
-            'query_hash': '37479f2b8209594dde7facb0d904896a',
+            'query_hash': '7dd9a7e2160524fd85f50317462cff9f',
             'variables': json.dumps(variables, separators=(',', ':'))
         }
 


### PR DESCRIPTION
## What does this PR do?

The most up to date version of the Instagram uses this endpoint to fetch the list of followers for a user. Notably, the result includes the `is_private` field for each follower.

## Why was this PR needed?

It's a nice improvement and it follows the current Instagram API more closely.

## What are the relevant issue numbers?

(List issue numbers here.)

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
