### PR TITLE
Add direct_v2_thread endpoint

### DIFF
--- a/instagram_private_api/endpoints/misc.py
+++ b/instagram_private_api/endpoints/misc.py
@@ -86,6 +86,19 @@ class MiscEndpointsMixin(object):
         """Get v2 inbox"""
         return self._call_api('direct_v2/inbox/')
 
+    def direct_v2_thread(self, thread, **kwargs):
+        """
+        Get v2 thread
+
+        :param thread:
+        :param kwargs:
+            - **cursor**: For pagination
+        :return:
+        """
+        endpoint = 'direct_v2/threads/{thread!s}/'.format(**{'thread': thread})
+        res = self._call_api(endpoint, query=kwargs)
+        return res
+
     def oembed(self, url, **kwargs):
         """
         Get oembed info

--- a/tests/private/misc.py
+++ b/tests/private/misc.py
@@ -34,6 +34,10 @@ class MiscTests(ApiTestBase):
                 'test': MiscTests('test_direct_v2_inbox', api)
             },
             {
+                'name': 'test_direct_v2_thread',
+                'test': MiscTests('test_direct_v2_thread', api)
+            },
+            {
                 'name': 'test_oembed',
                 'test': MiscTests('test_oembed', api)
             },

--- a/tests/private/misc.py
+++ b/tests/private/misc.py
@@ -100,6 +100,11 @@ class MiscTests(ApiTestBase):
         results = self.api.direct_v2_inbox()
         self.assertEqual(results.get('status'), 'ok')
 
+    def test_direct_v2_thread(self):
+        results = self.api.direct_v2_thread()
+        self.assertIsNotNone(results.get('thread'))
+        self.assertEqual(results.get('status'), 'ok')
+
     def test_oembed(self):
         results = self.api.oembed('https://www.instagram.com/p/BJL-gjsDyo1/')
         self.assertIsNotNone(results.get('html'))


### PR DESCRIPTION
## What does this PR do?

Add the direct_v2/threads/(thread ID) endpoint

## Why was this PR needed?

So that you can access your DMs (to backup messages, etc)

## What are the relevant issue numbers?

(none)

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [x] Is covered by a test
