### PR TITLE
Support socks proxies via PySocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.5"
 
 install:
-  - pip install flake8 'pylint<2.0'
+  - pip install flake8 'pylint<2.0' PySocks
 
 script:
 - flake8 --max-line-length=120 --exclude=./setup.py,./instagram_private_api/compat.py,./instagram_web_api/compat.py,./instagram_private_api/endpoints/__init__.py

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -17,6 +17,8 @@ from functools import wraps
 import string
 import random
 from socket import timeout, error as SocketError
+import socks
+from sockshandler import SocksiPyHandler
 from ssl import SSLError
 from .compat import (
     compat_urllib_request, compat_urllib_parse,
@@ -106,8 +108,15 @@ class Client(object):
             warnings.warn('Proxy support is alpha.', UserWarning)
             parsed_url = compat_urllib_parse_urlparse(proxy)
             if parsed_url.netloc and parsed_url.scheme:
-                proxy_address = '{0!s}://{1!s}'.format(parsed_url.scheme, parsed_url.netloc)
-                proxy_handler = compat_urllib_request.ProxyHandler({'https': proxy_address})
+                if parsed_url.scheme == 'socks5':
+                    proxy_handler = SocksiPyHandler(socks.SOCKS5, parsed_url.hostname, parsed_url.port,
+                                                    username=parsed_url.username, password=parsed_url.password)
+                elif parsed_url.scheme == 'socks4':
+                    proxy_handler = SocksiPyHandler(socks.SOCKS4, parsed_url.hostname, parsed_url.port,
+                                                    username=parsed_url.username, password=parsed_url.password)
+                else:
+                    proxy_address = '{0!s}://{1!s}'.format(parsed_url.scheme, parsed_url.netloc)
+                    proxy_handler = compat_urllib_request.ProxyHandler({'https': proxy_address})
             else:
                 raise ValueError('Invalid proxy argument: {0!s}'.format(proxy))
         handlers = []

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -456,7 +456,7 @@ class Client(object):
         if end_cursor:
             variables['after'] = end_cursor
         query = {
-            'query_hash': 'e7e2f4da4b02303f74f0841279e52d76',
+            'query_hash': 'f412a8bfd8332a76950fefc1da5785ef',
             'variables': json.dumps(variables, separators=(',', ':'))
         }
         info = self._make_request(self.GRAPHQL_API_URL, query=query)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ flake8>=3.3.0
 Sphinx>=1.5.1
 sphinx-rtd-theme>=0.1.9
 pylint
+PySocks==1.6.8


### PR DESCRIPTION
## What does this PR do?

Allow for socks5:// and socks4:// scheme proxies
to use the SocksiPyHandler provided by PySocks

## Why was this PR needed?

urllib doesn't support socks proxies natively

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [X] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test: no existing proxy tests
