### PR TITLE
Allow for pagination in direct_v2_inbox()

### DIFF
--- a/instagram_private_api/endpoints/misc.py
+++ b/instagram_private_api/endpoints/misc.py
@@ -82,9 +82,20 @@ class MiscEndpointsMixin(object):
         return self._call_api(
             'news/inbox/', query={'limited_activity': 'true', 'show_su': 'true'})
 
-    def direct_v2_inbox(self):
-        """Get v2 inbox"""
-        return self._call_api('direct_v2/inbox/')
+    def direct_v2_inbox(self, oldest_cursor=None):
+        """
+        Get v2 inbox
+        To retrieve the second page of the inbox, pass the oldest_cursor
+        returned by the previous direct_v2_inbox() call
+        """
+        query = {}
+        if oldest_cursor:
+            query = {
+                '__a': 1,
+                'max_id': oldest_cursor
+            }
+
+        return self._call_api('direct_v2/inbox/', query=query)
 
     def oembed(self, url, **kwargs):
         """


### PR DESCRIPTION
Added oldest_cursor parameter to direct_v2_inbox

## What does this PR do?

This PR allows the user to request the next page of the inbox from the Instagram API

## Why was this PR needed?

This PR is needed in any situation where a user wants to see more than the first 20 threads in the inbox

## What are the relevant issue numbers?

Issue #121

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [x] Is covered by a test
