### PR TITLE
Required aspect ratio too rigid for `post_album`

### DIFF
--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -738,8 +738,7 @@ class UploadEndpointsMixin(object):
                     raise ValueError('Duration not specified.')
                 if not media.get('thumbnail'):
                     raise ValueError('Thumbnail not specified.')
-            aspect_ratio = (media['size'][0] * 1.0) / (media['size'][1] * 1.0)
-            if not self.compatible_aspect_ratio(aspect_ratio):
+            if not self.compatible_aspect_ratio(media['size']):
                 raise ValueError('Invalid media aspect ratio.')
 
             if media['type'] == 'video':

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -739,7 +739,7 @@ class UploadEndpointsMixin(object):
                 if not media.get('thumbnail'):
                     raise ValueError('Thumbnail not specified.')
             aspect_ratio = (media['size'][0] * 1.0) / (media['size'][1] * 1.0)
-            if aspect_ratio > 1.0 or aspect_ratio < 1.0:
+            if not self.compatible_aspect_ratio(aspect_ratio):
                 raise ValueError('Invalid media aspect ratio.')
 
             if media['type'] == 'video':


### PR DESCRIPTION
## What does this PR do?

Fixed a line

## Why was this PR needed?

Can't post album with photos that aren't a square.
The required aspect ratio was too rigid for `post_album`

## What are the relevant issue numbers?

None

## Does this PR meet the acceptance criteria?

- [X] Passes flake8 (refer to ``.travis.yml``)
- [X] Docs are buildable
- [X] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
