### PR TITLE
Set log level to info for client.py

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -39,6 +39,7 @@ from .http import ClientCookieJar, MultipartFormDataEncoder
 from .common import ClientDeprecationWarning
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 warnings.simplefilter('always', ClientDeprecationWarning)
 
 

--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -1064,7 +1064,6 @@ class Client(object):
             reel_ids=reel_ids, tag_names=kwargs.pop('tag_names', []),
             location_ids=kwargs.pop('location_ids', []))
 
-    @login_required
     def highlight_reels(self, user_id):
         """
         Get the highlights for the specified user ID


### PR DESCRIPTION
Client.py has very verbose logs, so setting to INFO by default