### PR TITLE
login is NOT required for media_likers endpoint

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -591,8 +591,7 @@ class Client(object):
             return [c['node'] for c in info.get('data', {}).get('shortcode_media', {}).get(
                 'edge_media_to_comment', {}).get('edges', [])]
         return info
-
-    @login_required
+   
     def media_likers(self, short_code, **kwargs):
         """
         Get media likers


### PR DESCRIPTION
It allows users to get media_likers without logging in

(Briefly describe what this PR is about.)

@login_required attribute was added unnecessarily, the media_likers endpoint works fine without it

(Briefly describe reasons.)

No reported issues

(List issue numbers here.)

## Does this PR meet the acceptance criteria?

- [ ] Passes flake8 (refer to ``.travis.yml``)
- [ ] Docs are buildable
- [ ] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
