### PR TITLE
Remove rhx_gis from Web settings.json to fix JSON serializable TypeError

### DIFF
--- a/instagram_web_api/client.py
+++ b/instagram_web_api/client.py
@@ -177,7 +177,6 @@ class Client(object):
         return {
             'cookie': self.opener.cookie_jar.dump(),
             'created_ts': int(time.time()),
-            'rhx_gis': self.rhx_gis,
             'user_agent': self.user_agent,
         }
 


### PR DESCRIPTION
## What does this PR do?

When running tests OR trying to cache an authentication cookie using `instagram_web_api`, the following error is raised:

````
TypeError: <md5 HASH object @ 0x1099961e0> is not JSON serializable
```

This isn't needed and removing it allows for both `instagram_private_api` and `instagram_web_api` to be cached and reuse credentials.

## Why was this PR needed?

I was trying to merge both "cookie caching" modules and I saw in the "Test" there is an extra `--save` argument, then I went deeper and realised it was added to act as a quick bandaid fix. 

All together avoiding the caching which is okay considering it is a test and doesn't have to be run more than once, but in my (and others) case, it's required to run properly consecutively.

## What are the relevant issue numbers?

I have not made any issues regarding this instant.

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [] Is covered by a test
