### PR TITLE
fix empty 'profile_pic_url'

### DIFF
--- a/instagram_private_api/compatpatch.py
+++ b/instagram_private_api/compatpatch.py
@@ -429,7 +429,7 @@ class ClientCompatPatch(object):
         :meth:`Client.user_following`, :meth:`Client.user_followers`, :meth:`Client.search_users`
         """
         user['id'] = str(user['pk'])
-        user['profile_picture'] = user['profile_pic_url']
+        user['profile_picture'] = user.get('profile_pic_url','')
         if drop_incompat_keys:
             cls._drop_keys(
                 user,

--- a/instagram_private_api/compatpatch.py
+++ b/instagram_private_api/compatpatch.py
@@ -429,7 +429,7 @@ class ClientCompatPatch(object):
         :meth:`Client.user_following`, :meth:`Client.user_followers`, :meth:`Client.search_users`
         """
         user['id'] = str(user['pk'])
-        user['profile_picture'] = user.get('profile_pic_url','')
+        user['profile_picture'] = user.get('profile_pic_url', '')
         if drop_incompat_keys:
             cls._drop_keys(
                 user,


### PR DESCRIPTION
## What does this PR do?

returns empty string if 'profiel_pic_url' was not present in dict

## Why was this PR needed?

It will raise an error if 'profile_pic_url' won't be in the dict

## What are the relevant issue numbers?



## Does this PR meet the acceptance criteria?
yes
- [ ] Passes flake8 (refer to ``.travis.yml``)
- [ ] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
