### PR TITLE
instagram_private_api/http.py - ClientCookieJar.dump(args) :: Optiona…

### DIFF
--- a/instagram_private_api/client.py
+++ b/instagram_private_api/client.py
@@ -223,6 +223,19 @@ class Client(AccountsEndpointsMixin, DiscoverEndpointsMixin, FeedEndpointsMixin,
             'created_ts': int(time.time())
         }
 
+    def get_settings(self, protocol=None):
+        """Getter function that extracts the settings. The difference to the helper settings property above 
+        is that this getter can take a protocol argument to dump the cookie jar pickles in order to fix the
+        conversion errors of the default protocol (4, in contrast to 0 in Python 2.7) in Python 3.x."""
+        return {
+            'uuid': self.uuid,
+            'device_id': self.device_id,
+            'ad_id': self.ad_id,
+            'session_id': self.session_id,
+            'cookie': self.cookie_jar.dump(protocol=protocol),
+            'created_ts': int(time.time())
+        }
+
     @property
     def user_agent(self):
         """Returns the useragent string that the client is currently using."""

--- a/instagram_private_api/http.py
+++ b/instagram_private_api/http.py
@@ -30,8 +30,8 @@ class ClientCookieJar(compat_cookiejar.CookieJar):
         """For backward compatibility"""
         return self.auth_expires
 
-    def dump(self):
-        return compat_pickle.dumps(self._cookies)
+    def dump(self, protocol=None):
+        return compat_pickle.dumps(self._cookies, protocol=protocol)
 
 
 class MultipartFormDataEncoder(object):


### PR DESCRIPTION
…l argument protocol is added. instagram_private_api/client.py - Client :: New get_settings(args) function is defined that can take the optional argument protocol to be used in dumping cookie jar.

## What does this PR do?

Adds the option to decide with which protocol should the cookie jar be pickled.

## Why was this PR needed?

Python 2.7 pickle library uses protocol 0 as default but from 3.x+ protocol 4 is defined as default unless it is set by the user. I have realized protocol 4 had dumped a bytes object with control characters such as '\x80'. These characters often appeared in wrong places that rendered the utf-8 encoding invalid and could not be decoded into a string. This created issues in transferring the cookie in a json response if the user wished so.

## What are the relevant issue numbers?

No relevant issues that I could find about this.

## Does this PR meet the acceptance criteria?

- [X] Passes flake8 (refer to ``.travis.yml``)
- [X] Docs are buildable
- [X] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
