### PR TITLE
Added upload_image functionality

### DIFF
--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -388,7 +388,11 @@ class UploadEndpointsMixin(object):
             return ext
         return False
 
-    def upload_image(self, img, size, quality=80, caption='', location=None, disable_comments=False, story=False, **kwargs) -> bool:
+    def upload_image(self, img, size, quality=80, caption='',
+                     location=None,
+                     disable_comments=False,
+                     story=False,
+                     **kwargs) -> bool:
         """
         Upload an image and post it.
         :param img: io.BufferedReader
@@ -467,7 +471,7 @@ class UploadEndpointsMixin(object):
                 )
 
                 res = self.opener.open(req, timeout=self.timeout)
-                post_response = self._read_response(res)
+                self._read_response(res)
 
                 if story:
                     self.configure_to_reel(image_props['upload_id'], size)

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -388,16 +388,16 @@ class UploadEndpointsMixin(object):
             return ext
         return False
 
-    def upload_image(self, img, size, quality=80, caption='', location=None, disable_comments=False, is_sidecar=False, **kwargs) -> bool:
+    def upload_image(self, img, size, quality=80, caption='', location=None, disable_comments=False, story=False, **kwargs) -> bool:
         """
         Upload an image and post it.
-
         :param img: io.BufferedReader
         :param size: tuple of (width, height)
         :param caption:
         :param location: a dict of venue/location information, from :meth:`location_search`
         or :meth:`location_fb_search`
         :param disable_comments: bool to disable comments
+        :param story: bool to upload a story instead of a post
         :return bool:
         """
         is_img = self.is_image(img.name)
@@ -467,9 +467,12 @@ class UploadEndpointsMixin(object):
                 )
 
                 res = self.opener.open(req, timeout=self.timeout)
-                self._read_response(res)
+                post_response = self._read_response(res)
 
-                self.configure(image_props['upload_id'], size, caption=caption)
+                if story:
+                    self.configure_to_reel(image_props['upload_id'], size)
+                else:
+                    self.configure(image_props['upload_id'], size, caption=caption)
 
                 return True
 

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -3,8 +3,6 @@ import time
 from secrets import choice
 import re
 import warnings
-from urllib.parse import urlparse
-from os.path import splitext
 import uuid
 
 from ..compat import (
@@ -15,7 +13,7 @@ from ..errors import ErrorHandler, ClientError, ClientConnectionError
 from ..http import MultipartFormDataEncoder
 from ..utils import (
     max_chunk_count_generator, max_chunk_size_generator,
-    get_file_size
+    get_file_size, is_image_jpg
 )
 from ..compatpatch import ClientCompatPatch
 from .common import ClientDeprecationWarning
@@ -380,14 +378,6 @@ class UploadEndpointsMixin(object):
             ClientCompatPatch.media(res.get('media'), drop_incompat_keys=self.drop_incompat_keys)
         return res
 
-    def is_image(self, url):
-        image_formats = [".jpeg", ".jpg"]
-        parsed = urlparse(url)
-        ext = splitext(parsed.path)[1]
-        if ext in image_formats:
-            return ext
-        return False
-
     def upload_image(self, img, size, quality=80, caption='',
                      location=None,
                      disable_comments=False,
@@ -404,7 +394,7 @@ class UploadEndpointsMixin(object):
         :param story: bool to upload a story instead of a post
         :return bool:
         """
-        is_img = self.is_image(img.name)
+        is_img = is_image_jpg(img.name)
 
         if is_img:
             image_props = {

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -1,6 +1,6 @@
 import json
 import time
-from random import randint
+from secrets import choice
 import re
 import warnings
 from urllib.parse import urlparse
@@ -302,8 +302,8 @@ class UploadEndpointsMixin(object):
         params = {
             'source_type': '4',
             'upload_id': upload_id,
-            'story_media_creation_date': str(int(time.time()) - randint(11, 20)),
-            'client_shared_at': str(int(time.time()) - randint(3, 10)),
+            'story_media_creation_date': str(int(time.time()) - choice(range(11, 20))),
+            'client_shared_at': str(int(time.time()) - choice(range(3, 10))),
             'client_timestamp': str(int(time.time())),
             'configure_mode': 1,      # 1 - REEL_SHARE, 2 - DIRECT_STORY_SHARE
             'device': {
@@ -348,8 +348,8 @@ class UploadEndpointsMixin(object):
         params = {
             'source_type': '4',
             'upload_id': upload_id,
-            'story_media_creation_date': str(int(time.time()) - randint(11, 20)),
-            'client_shared_at': str(int(time.time()) - randint(3, 10)),
+            'story_media_creation_date': str(int(time.time()) - choice(range(11, 20))),
+            'client_shared_at': str(int(time.time()) - choice(range(3, 10))),
             'client_timestamp': str(int(time.time())),
             'configure_mode': 1,      # 1 - REEL_SHARE, 2 - DIRECT_STORY_SHARE
             'poster_frame_index': 0,
@@ -383,7 +383,7 @@ class UploadEndpointsMixin(object):
     def is_image(self, url):
         image_formats = [".jpeg", ".jpg"]
         parsed = urlparse(url)
-        root, ext = splitext(parsed.path)
+        ext = splitext(parsed.path)[1]
         if ext in image_formats:
             return ext
         return False
@@ -408,7 +408,7 @@ class UploadEndpointsMixin(object):
 
         if is_img:
             image_props = {
-                'caption': '',
+                'caption': caption,
                 'edits': {
                     'crop_center': [0.0, 0.0],
                     'crop_original_size': size,
@@ -429,7 +429,7 @@ class UploadEndpointsMixin(object):
                 'x_fb_waterfall_id': str(uuid.uuid4())
             }
 
-            image_props['entity_name'] = f'{image_props["upload_id"]}_0_{randint(1000000000, 9999999999)}'
+            image_props['entity_name'] = f'{image_props["upload_id"]}_0_{choice(range(1000000000, 9999999999))}'
 
             with open(img.name, 'rb') as f:
                 f.seek(0, 2)
@@ -476,7 +476,8 @@ class UploadEndpointsMixin(object):
                 if story:
                     self.configure_to_reel(image_props['upload_id'], size)
                 else:
-                    self.configure(image_props['upload_id'], size, caption=caption)
+                    self.configure(image_props['upload_id'], size, caption=caption,
+                                   location=location, disable_comments=disable_comments)
 
                 return True
 

--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -387,7 +387,7 @@ class UploadEndpointsMixin(object):
         if ext in image_formats:
             return ext
         return False
-    
+
     def upload_image(self, img, size, quality=80, caption='', location=None, disable_comments=False, is_sidecar=False, **kwargs) -> bool:
         """
         Upload an image and post it.
@@ -467,7 +467,7 @@ class UploadEndpointsMixin(object):
                 )
 
                 res = self.opener.open(req, timeout=self.timeout)
-                post_response = self._read_response(res)
+                self._read_response(res)
 
                 self.configure(image_props['upload_id'], size, caption=caption)
 

--- a/instagram_private_api/utils.py
+++ b/instagram_private_api/utils.py
@@ -6,7 +6,7 @@ from random import randint
 import os
 from datetime import datetime
 import re
-
+from .compat import compat_urllib_parse_urlparse
 
 VALID_UUID_RE = r'^[a-f\d]{8}\-[a-f\d]{4}\-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}$'
 
@@ -263,3 +263,18 @@ class InstagramID(object):
         :return:
         """
         return cls._decode(short_code)
+
+
+def is_image_jpg(url):
+    """
+    Check if an image has JPG extension
+
+    :param url: URL or filename
+    :return: str or bool
+    """
+    image_formats = [".jpeg", ".jpg"]
+    parsed = compat_urllib_parse_urlparse(url)
+    ext = os.path.splitext(parsed.path)[1]
+    if ext in image_formats:
+        return ext
+    return False


### PR DESCRIPTION
## What does this PR do?

Added upload_image functionality for both posts and stories

```
from PIL import Image
from instagram_private_api import Client

api = Client(username=...,password=...)

with Image.open('/Users/kn0wm4d/Desktop/test.jpg') as img:
   photo_data = open('/Users/kn0wm4d/Desktop/test.jpg', 'rb')
   width, height = img.size
   size = (width, height)

api.upload_image(photo_data, quality=80, size=size, caption='Test', story=False)

```

## Why was this PR needed?

Because IG deprecated post_photo (experimental endpoint).

## What are the relevant issue numbers?

#305 

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
