### PR TITLE
 Get presence of people from direct messages

### DIFF
--- a/instagram_private_api/endpoints/friendships.py
+++ b/instagram_private_api/endpoints/friendships.py
@@ -392,3 +392,11 @@ class FriendshipsEndpointsMixin(object):
             'friendships/remove_follower/{user_id!s}/'.format(**{'user_id': user_id}),
             params=params)
         return res
+    def get_presence(self):
+        """
+        Get presence of people from direct messages
+
+        :return:
+        """
+        res = self._call_api('direct_v2/get_presence/')
+        return res


### PR DESCRIPTION
## What does this PR do?

 Gets presence of people from direct messages

## Why was this PR needed?

Becouse i coudn't get who was online and wasn't

## What are the relevant issue numbers?

None

## Does this PR meet the acceptance criteria?

- [x] Passes flake8 (refer to ``.travis.yml``)
- [x] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test
