### PR TITLE
README one-line: add link to cached auth settings example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ You are advised to persist/cache the auth cookie details to avoid logging in eve
 
 The saved auth cookie can be reused for up to **90 days**.
 
+An example of how to save and reuse the auth settings can be found in the [examples](examples/savesettings_logincallback.py).
+
 ## Donate
 
 Want to keep this project going? Please donate generously [https://www.buymeacoffee.com/ping](https://www.buymeacoffee.com/ping)


### PR DESCRIPTION
## What does this PR do?

Minor change to README.md - adds link to the example.py file showing users how to cache (same line is actually included in the [docs/usage.rst](https://github.com/ping/instagram_private_api/blob/master/docs/usage.rst) file)

## Why was this PR needed?

Quicker reference for people working out of the github repo rather than readthedocs.io

## What are the relevant issue numbers?

did not create issue, since this is a one-line change just to README

## Does this PR meet the acceptance criteria?
(I'm marking all 4 as pass given the above note in issue numbers question)

- [X] Passes flake8 (refer to ``.travis.yml``)
- [X] Docs are buildable
- [X] Branch has no merge conflicts with ``master``
- [X] Is covered by a test
