### PR TITLE
Fix current_user 405 error (#312)

### DIFF
--- a/instagram_private_api/endpoints/accounts.py
+++ b/instagram_private_api/endpoints/accounts.py
@@ -75,8 +75,7 @@ class AccountsEndpointsMixin(object):
 
     def current_user(self):
         """Get current user info"""
-        params = self.authenticated_params
-        res = self._call_api('accounts/current_user/', params=params, query={'edit': 'true'})
+        res = self._call_api('accounts/current_user/', query={'edit': 'true'})
         if self.auto_patch:
             ClientCompatPatch.user(res['user'], drop_incompat_keys=self.drop_incompat_keys)
         return res


### PR DESCRIPTION
## What does this PR do?
It fixes the "405 Method Not Allowed" error caused by sending a request to the current_user endpoint with the POST method. The current_user endpoint only supports the GET method.

## Why was this PR needed?
The current_user endpoint is currently unavailable due to the error "405 Method Not Allowed"

## What are the relevant issue numbers?
#312

## Does this PR meet the acceptance criteria?

- [ x ] Passes flake8 (refer to ``.travis.yml``)
- [ x ] Docs are buildable
- [ x ] Branch has no merge conflicts with ``master``
- [ x ] Is covered by a test
